### PR TITLE
add: tensorboard, psnr

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get update && apt-get install -y \
     libegl1-mesa-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install fastapi uvicorn numpy torch torchvision pillow scikit-image moderngl OpenEXR piq pandas torch_dct
+RUN pip install fastapi uvicorn numpy torch torchvision pillow scikit-image moderngl OpenEXR piq pandas torch_dct tensorboard
 
-EXPOSE 8000
+EXPOSE 8000 6006
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--log-level", "debug"]

--- a/backend/ai/experiments.py
+++ b/backend/ai/experiments.py
@@ -143,10 +143,31 @@ EXPERIMENTS = []
 #     }
 # ]
 
+# EXPERIMENTS += [
+#     {
+#         "name": "Benchmark1",
+#         "dataset": "vid_compression/beauty",
+#         "config": {
+#             "latent_dim": 0,
+#             "trunk_pos_channels": 2,
+#             "trunk_time_channels": 1,
+#             "film_pos_channels": 64,
+#             "film_time_channels": 8,
+#             "film_pos_scheme": "sinusoidal",
+#             "film_time_scheme": "sinusoidal",
+#             "film_pos_include_raw": True,
+#             "film_time_include_raw": True,
+#             "prefilm_dims": 32,
+#             "hidden_dim": 64,
+#             "apply_film": [1],
+#         }
+#     }
+# ]
+
 EXPERIMENTS += [
     {
-        "name": "Benchmark1",
-        "dataset": "vid_compression/beauty",
+        "name": "FireCircle",
+        "dataset": "VFX/fire-circle",
         "config": {
             "latent_dim": 0,
             "trunk_pos_channels": 2,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: horde-backend
     ports:
       - "8000:8000"
+      - "6006:6006"
     volumes:
       - ./backend:/app
       - ./static:/app/static


### PR DESCRIPTION
## Summary by Sourcery

Integrate comprehensive TensorBoard support into the VFX training pipeline with detailed metrics and image logging, introduce optional image downsampling, standardize image loading to float32, update experiment default, and expose TensorBoard in Docker configuration

New Features:
- Integrate TensorBoard for logging training metrics, gradient norms, PSNR/SSIM, model and config details, and image comparisons
- Add max_image_size option to downsample large input images while preserving aspect ratio during loading

Enhancements:
- Track and log individual loss components (MSE, DCT, L1) and PSNR per batch and epoch in train_vfx_model
- Implement PSNR and SSIM evaluation on generated frames at sample time points and log results to TensorBoard
- Use float32 for image and EXR loading for improved precision and consistency

Build:
- Include tensorboard in backend Dockerfile and expose port 6006; update docker-compose to map port 6006

Documentation:
- Add or improve docstrings for train_vfx_model and load_images functions

Chores:
- Rename default experiment to FireCircle and comment out Benchmark1 scaffold in experiments.py